### PR TITLE
scrollable panes, tooltip and history back

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -13,7 +13,7 @@
       </div>
     </div>
     <div class="maincontainer">
-      <NavigationBar></NavigationBar> 
+      <NavigationBar></NavigationBar>
       <div class="main">
         <router-view></router-view>
       </div>
@@ -127,17 +127,17 @@ input {
 
 /* Track */
 ::-webkit-scrollbar-track {
-    background: $nord0; 
+    background: $nord0;
 }
 
 /* Handle */
 ::-webkit-scrollbar-thumb {
-    background: $nord14; 
+    background: $nord14;
 }
 
 /* Handle on hover */
 ::-webkit-scrollbar-thumb:hover {
-    background: $nord3; 
+    background: $nord3;
 }
 
 .errorMessage {
@@ -211,7 +211,7 @@ a.normallink, a.normallink:hover, a.normallink:visited {
 .evt {
     border-top: 1px solid rgba(255, 255, 255, 0.1);
     border-right: 1px solid rgba(255, 255, 255, 0.1);
-    /* font-family: 'Courier New', Courier, monospace; 
+    /* font-family: 'Courier New', Courier, monospace;
     font-size: 0.9em;*/
 }
 .evtvalue {
@@ -222,6 +222,12 @@ a.normallink, a.normallink:hover, a.normallink:visited {
 }
 .evtrow {
     font-size: 0.8rem;
+
+    .keycol {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
 }
 .fullvalue {
   font-size: 0.9em;
@@ -273,7 +279,7 @@ pre {
 .zset {
   color: $nord12 !important;
 }
- 
+
 .hash {
   background: $nord14;
   color: $nord3;
@@ -336,7 +342,7 @@ a:hover {
 #pubsubwrapper {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
-  grid-template-rows: 200px, auto; 
+  grid-template-rows: 200px, auto;
 }
 #pubsubmessages {
   display:grid;
@@ -360,5 +366,11 @@ a:hover {
 .score, .member {
   border-bottom: 1px solid $nord3;
   border-right: 1px solid $nord3;
+}
+// assumption is 2 child elements
+.historyview > * {
+  max-height: 50vh;
+  overflow-y: auto;
+  word-wrap: break-word;
 }
 </style>

--- a/src/renderer/components/Redis/Event.vue
+++ b/src/renderer/components/Redis/Event.vue
@@ -6,9 +6,11 @@
                         {{ event.type }}
             </div>
             <div class="col-md-4 keycol evt">
-              <router-link :to="{ name: 'history', params: { key: event.key, type: event.type }}">{{ evtKey }}</router-link>
+              <router-link
+                :to="{ name: 'history', params: { key: event.key, type: event.type }}"
+                :title="event.key">{{ event.key }}</router-link>
             </div>
-            <div class="col-md-7 evt evtvalue">{{ event.value }}</div>
+            <div class="col-md-7 evt evtvalue"><a :title="event.value">{{ event.value }}</a></div>
         </div>
     </div>
 </template>
@@ -17,10 +19,5 @@
 export default {
   name: 'Event',
   props: ['event'],
-  computed: {
-    evtKey() {
-      return (this.event && this.event.key && this.event.key.length > 20) ? `${this.event.key.substring(0, 50)}...` : this.event.key;
-    },
-  },
 };
 </script>

--- a/src/renderer/components/Redis/History.vue
+++ b/src/renderer/components/Redis/History.vue
@@ -1,6 +1,7 @@
 <template>
-  <div class="container-fluid">
+  <div class="container-fluid historyview">
     <div class="row">
+      <a @click="back" class="uilink">back</a>
       <label><h2>history of [ {{ type }} ]: {{ key }}</h2></label>
     </div>
     <div class="maincontent" id="historylist">
@@ -44,6 +45,11 @@ export default {
       } catch (_err) {
         return v;
       }
+    },
+  },
+  methods: {
+    back() {
+      window.history.go(-1);
     },
   },
   components: {


### PR DESCRIPTION
Watch view:
* The hardcoded ellipsis didn't correspond to the fluid container, made the ellipsis CSS based
* Also added HTML-based tooltip with full content

History view:
* Back button for easier navigation
* Scrollable panes for key and history, both of which had responsive sizing, but contents which didn't wrap right (there was truncation previously).